### PR TITLE
Add Segment snippet to load Analytics.js using contentFor hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@ Ember CLI addons that provides a clean and easy way to integrate your Ember appl
 
 ## Configuration/Logging
 
-There is one option available to configure the events log tracking, the default value is `false`. This option is optional, but recommended.
+Add your Segment `WRITE_KEY` to the `segment` config object for Analytics.js to be loaded and configured automatically.
+
+There is an option available to configure the events log tracking, the default value is `false`. This option is optional, but recommended.
 
 In your `config/environment.js`
 
 ```js
 ENV['segment'] = {
+  WRITE_KEY: 'your_segment_write_key',
   LOG_EVENT_TRACKING: true
 };
 

--- a/index.js
+++ b/index.js
@@ -2,5 +2,20 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-cli-segment'
+  name: 'ember-cli-segment',
+
+  contentFor: function (type, config) {
+    if (type === 'head') {
+
+      if (!config.segment || !config.segment.WRITE_KEY) {
+        return '';
+      }
+
+      return `<script type="text/javascript">
+                !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";
+                  analytics.load("${config.segment.WRITE_KEY}");
+                }}();
+             </script>`;
+    }
+  },
 };


### PR DESCRIPTION
When the addon is loaded it will now look for WRITE_KEY on the segment config object.
If present it will include a JS snippet taken from the Segment install guide and pass in the key.
